### PR TITLE
Avoid risks of PATH exploits

### DIFF
--- a/src/ethercat_grant.cpp
+++ b/src/ethercat_grant.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
 
   // Copy new executable to /var/tmp
   string cmd;
-  cmd = string("cp ") + string(argv[1]) + string(" " EXECUTABLE);
+  cmd = string("/bin/cp ") + string(argv[1]) + string(" " EXECUTABLE);
   if (system(cmd.c_str()) == -1) {
     perror("cp");
     return -1;


### PR DESCRIPTION
Hi, 
while trying to fix #4 I looked for environment variable preserving when executing with suid, and found there are actually vulnerabilities when doing system calls in a program with suid.

http://techblog.rosedu.org/exploiting-environment-variables.html
and for a more recent
https://www.hackingarticles.in/linux-privilege-escalation-using-path-variable/

this line  https://github.com/shadow-robot/ethercat_grant/blob/kinetic-devel/src/ethercat_grant.cpp#L27 carries the potential risk  even if I did not manage to reproduce the exploit (not sure what protects this yet), I think it would not be harmful to change the cp to its full linux path /bin/cp to avoid the PATH exploit

