### PR TITLE
Update cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ethercat_grant)
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
Increased the minimum required CMake version in order to avoid [author warning](https://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning).